### PR TITLE
optimize dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,27 @@
-FROM rust:1.58.1
+FROM lukemathwalker/cargo-chef:latest-rust-1.58.1 AS chef
+WORKDIR app
 
 RUN cargo install sccache
-
-WORKDIR /app
-
 ENV SCCACHE_CACHE_SIZE="1G"
 ENV SCCACHE_DIR=$HOME/.cache/sccache
 ENV RUSTC_WRAPPER="/usr/local/cargo/bin/sccache"
 
+FROM chef AS planner
 COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
+FROM chef AS builder
+
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --recipe-path recipe.json
+# Build application
+COPY . .
 RUN --mount=type=cache,target=/app/.cache/sccache \
-    cargo build --release
+    cargo build --release --bin bot
 
-ENTRYPOINT ["/app/target/release/bot"]
+# We do not need the Rust toolchain to run the binary!
+FROM debian:buster-slim AS runtime
+WORKDIR app
+COPY --from=builder /app/target/release/bot /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/bot"]


### PR DESCRIPTION
2回目以降のdocker buildの比較を行い、約155秒(2分~)ほどの短縮を行えることを確認した。

ref: https://github.com/LukeMathWalker/cargo-chef

以前

```
docker build -t ictsc/ictsc-kana:2eba24f .
[+] Building 179.4s (10/10) FINISHED                                                                                                                                    

 => [internal] load build definition from Dockerfile                                                                                                               0.0s
 => => transferring dockerfile: 38B                                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                                  0.0s
 => => transferring context: 34B                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/rust:1.58.1                                                                                                     1.6s
 => [stage-0 1/5] FROM docker.io/library/rust:1.58.1@sha256:e4979d36d5d30838126ea5ef05eb59c4c25ede7f064985e676feb21402d0661b                                       0.0s
 => [internal] load build context                                                                                                                                  0.0s
 => => transferring context: 17.67kB                                                                                                                               0.0s
 => CACHED [stage-0 2/5] RUN cargo install sccache                                                                                                                 0.0s
 => CACHED [stage-0 3/5] WORKDIR /app                                                                                                                              0.0s
 => [stage-0 4/5] COPY . .                                                                                                                                         0.2s
 => [stage-0 5/5] RUN --mount=type=cache,target=/app/.cache/sccache     cargo build --release                                                                    172.5s
 => exporting to image                                                                                                                                             5.0s
 => => exporting layers                                                                                                                                            5.0s
 => => writing image sha256:02a60ba9035697cf409cf654acff38cbc47483642e5f344e4bde3b57ef72e1f9                                                                       0.0s 
 => => naming to docker.io/ictsc/ictsc-kana:2eba24f 
```

このPR
```
docker build -t ictsc/ictsc-kana:2eba24f .
[+] Building 24.9s (18/18) FINISHED                                                                                                                                     

 => [internal] load build definition from Dockerfile                                                                                                               0.0s
 => => transferring dockerfile: 38B                                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                                  0.0s
 => => transferring context: 34B                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/debian:buster-slim                                                                                              0.8s
 => [internal] load metadata for docker.io/lukemathwalker/cargo-chef:latest-rust-1.58.1                                                                            0.8s
 => [chef 1/3] FROM docker.io/lukemathwalker/cargo-chef:latest-rust-1.58.1@sha256:465039325a38db027926f89bb62406837a8c76c7d807c511e638fd7d568023e6                 0.0s
 => [internal] load build context                                                                                                                                  0.0s
 => => transferring context: 17.64kB                                                                                                                               0.0s
 => [runtime 1/3] FROM docker.io/library/debian:buster-slim@sha256:f6e5cbc7eaaa232ae1db675d83eabfffdabeb9054515c15c2fb510da6bc618a7                                0.0s
 => CACHED [chef 2/3] WORKDIR app                                                                                                                                  0.0s
 => CACHED [chef 3/3] RUN cargo install sccache                                                                                                                    0.0s
 => [planner 1/2] COPY . .                                                                                                                                         0.1s
 => [planner 2/2] RUN cargo chef prepare --recipe-path recipe.json                                                                                                 0.6s
 => CACHED [builder 1/4] COPY --from=planner /app/recipe.json recipe.json                                                                                          0.0s
 => CACHED [builder 2/4] RUN cargo chef cook --release --recipe-path recipe.json                                                                                   0.0s
 => [builder 3/4] COPY . .                                                                                                                                         0.1s
 => [builder 4/4] RUN --mount=type=cache,target=/app/.cache/sccache     cargo build --release --bin bot                                                           22.8s
 => CACHED [runtime 2/3] WORKDIR app                                                                                                                               0.0s 
 => CACHED [runtime 3/3] COPY --from=builder /app/target/release/bot /usr/local/bin                                                                                0.0s 
 => exporting to image                                                                                                                                             0.0s 
 => => exporting layers                                                                                                                                            0.0s 
 => => writing image sha256:a8b24e64a8450ee0da694185d48cb656acf1c09d8e9df34b7d36eda63017918f                                                                       0.0s 
 => => naming to docker.io/ictsc/ictsc-kana:2eba24f
 ```