### PR TITLE
トピックの情報から踏み台サーバの情報を削除した

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -343,16 +343,10 @@ impl Bot {
     }
 
     fn create_topic(&self, team: &TeamConfiguration) -> String {
-        format!("**__踏み台サーバ__**
-
-ホスト名：{id}.bastion.ictsc.net
-ユーザ名：user
-パスワード：{invitation_code}
-
-**__スコアサーバ__**
+        format!("**__スコアサーバ__**
 
 ユーザ登録URL：https://contest.ictsc.net/signup?invitation_code={invitation_code}&user_group_id={user_group_id}",
-                id = team.id, invitation_code = team.invitation_code, user_group_id = team.user_group_id)
+                invitation_code = team.invitation_code, user_group_id = team.user_group_id)
     }
 
     #[tracing::instrument(skip_all)]


### PR DESCRIPTION
スコアサーバのチーム情報内に表示されるため、こちらから削除した。